### PR TITLE
Fixed status server error on game server shutdown

### DIFF
--- a/src/ServerListPing/SLPServer.cs
+++ b/src/ServerListPing/SLPServer.cs
@@ -50,14 +50,14 @@ namespace StatusServer.ServerListPing
 
         private async Task Listen()
         {
-            while (true)
-            {
-                try {
+            try { 
+                while (true)
+                {
                     var client = await _listener.AcceptTcpClientAsync();
                     var stream = client.GetStream();
 
                     var reader = new BinaryReader(stream);
-                    
+
                     // Handshake: https://wiki.vg/Protocol#Handshake
                     /* Packet length */ var length = reader.Read7BitEncodedInt();
                     if (length == 0xFE) // Legacy
@@ -73,19 +73,19 @@ namespace StatusServer.ServerListPing
                     /* Host */          reader.ReadString();
                     /* Port */          reader.ReadUInt16();
                     var state = reader.Read7BitEncodedInt();
-                    
+
                     if (state != 1) continue; // Login (ignore)
 
                     HandlePacket(stream);
-                    
+
                     // Follow-on ping (optional)
                     HandlePacket(stream);
                     client.Close();
                 }
-                catch (TargetInvocationException) { }
-                catch (IOException) { }
-                catch (SocketException) { }
             }
+            catch (TargetInvocationException) { }
+            catch (IOException) { }
+            catch (SocketException) { }
         }
         
         /// <summary>


### PR DESCRIPTION
Previously there was try-catch inside `while (true)` wich led to exceptions throwing but not cycle breaking (as I understand).

And since cycle was not breaked, it tried to call `AcceptTcpClientAsync` on already closed listener

```
/stop
9.4.2025 18:11:04 [Server Notification] Handling Console Command /stop
9.4.2025 18:11:04 [Server Notification] Message to all in group 0: Console Admin начал остановку работы сервера
9.4.2025 18:11:04 [Server Event] Console Admin shuts down server.
9.4.2025 18:11:04 [Server Notification] Server stop requested, begin shutdown sequence. Stop reason: Shutdown via server command
9.4.2025 18:11:04 [Server Notification] Server ticking has been suspended
9.4.2025 18:11:04 [Server Notification] Entering runphase Shutdown
9.4.2025 18:11:04 [Server Notification] [statusserver] Status server stopped
9.4.2025 18:11:04 [Server Error] [statusserver] Not listening. You must call the Start() method before calling this method.   at System.Net.Sockets.TcpListener.AcceptSocketAsync(CancellationToken cancellationToken)
   at System.Net.Sockets.TcpListener.AcceptTcpClientAsync()
   at StatusServer.ServerListPing.StatusTcpServer.Listen()
   at StatusServer.ServerListPing.StatusTcpServer.Start()
9.4.2025 18:11:04 [Server Notification] [statusserver] Status server stopped due an exception
```