### PR TITLE
Fixed error if someone requests the status too early. And start listen delay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,99 @@
-﻿# Status Server
-Vintage Story mod that provides game server information 
-via popular [Server List Ping](https://wiki.vg/Server_List_Ping) protocol.
+# Status Server Revised
 
-## Configure
-1. Run the server with mod installed for the first time to generate default config file.
-2. Open TCP port specified in mod config (You can't share the same port with Vintage Story game server).
-3. <kbd>(Optional)</kbd> Add server icon (64x64, PNG only) path relative to VintagestoryServer executable (or use absolute path).
+Vintage Story mod that provides game server information via the popular [Server List Ping](https://wiki.vg/Server_List_Ping) protocol.
 
-**Default config file**
+This is an optimized and extended fork of the original [Status Server](https://github.com/Nyuhnyash/VSStatusServer) mod by Nyuhnyash.
+
+## Features
+
+- **Server List Ping protocol** — compatible with Minecraft server list tools
+- **Rate limiting** — per-IP request throttling for DDoS protection
+- **Parallel client handling** — non-blocking request processing
+- **Extension system** — modular architecture for custom status data
+- **Configurable** — timeouts, connection limits, and more
+
+## Installation
+
+1. Download the latest release (`StatusServerRevised_vX.X.X.zip`)
+2. Place it in your server's `Mods` folder
+3. Start the server to generate the config file
+4. Open TCP port specified in config (default: 25565)
+
+## Configuration
+
+Config file: `ModConfig/statusserverrevised.json`
+
 ```json
 {
     "Port": 25565,
     "IconFile": "server-icon.png",
-    "EnabledExtensions": [ "world" ]
+    "StartDelaySeconds": 10,
+    "EnabledExtensions": ["world"],   
+    "ClientTimeoutMs": 5000,
+    "Backlog": 10,
+    "MaxConcurrentConnections": 50,
+    "EnableRateLimiting": true,
+    "RateLimitWindowSeconds": 60,
+    "RateLimitMaxRequests": 30
 }
 ```
 
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `Port` | 25565 | TCP port for the status server |
+| `IconFile` | server-icon.png | Server icon path (64x64 PNG) |
+| `StartDelaySeconds` | 10 | Delay before starting listener (prevents early request errors) |
+| `EnabledExtensions` | ["world"] | Enabled status extensions |
+| `ClientTimeoutMs` | 5000 | Client connection timeout |
+| `Backlog` | 10 | Maximum pending connections |
+| `MaxConcurrentConnections` | 50 | Maximum simultaneous connections |
+| `EnableRateLimiting` | true | Enable per-IP rate limiting |
+| `RateLimitWindowSeconds` | 60 | Rate limit time window |
+| `RateLimitMaxRequests` | 30 | Max requests per IP per window |
+
 ## Build
-- Set `VINTAGE_STORY` environment variable to your game directory.
-- Get ready-to-publish mod as zip archive
+
 ```shell
+# Set VINTAGE_STORY environment variable to your game directory
 dotnet build -c Release
 ```
 
-## Usage example
-There are plenty of libraries implementing the protocol: 
-[mcstatus](https://github.com/py-mine/mcstatus), 
-[mcutil](https://github.com/mcstatus-io/mcutil),
-etc.
-[More examples](https://wiki.vg/Server_List_Ping#Examples).
+Output: `bin/Release/StatusServerRevised_v1.0.0.zip`
 
-Ready-to-use services:
-https://mcsrvstat.us, 
-https://mcstatus.io,
-Telegram bot [@msmpbot](https://t.me/msmpbot).
+## Usage
 
-### Demonstration
+Compatible with any Server List Ping client:
+- [mcstatus](https://github.com/py-mine/mcstatus) (Python)
+- [mcutil](https://github.com/mcstatus-io/mcutil) (Go)
+- [More examples](https://wiki.vg/Server_List_Ping#Examples)
 
-#### Ping result
+Online services: [mcsrvstat.us](https://mcsrvstat.us), [mcstatus.io](https://mcstatus.io)
+
+### Example
+
 ```shell
-user@pc:~$ mcstatus localhost:25565 ping
-2.0397999905981123ms
-```
-
-#### Status result
-```shell
-user@pc:~$ mcstatus localhost:25565 status
-version: v1.18.0-pre.6 (protocol 2000)
+$ mcstatus localhost:25565 status
+version: v1.19.0 (protocol 2000)
 description: "Vintage Story Server"
-players: 1/16 ['Nyuhnyash (3e4a67aa-c4f1-f5f7-dffd-37e2fad5f74d)']
+players: 1/16 ['RainYbit (3e4a67aa-c4f1-f5f7-dffd-37e2fad5f74d)']
 ```
 
-Operate raw json to access non-standard extensions data.
+### JSON Response
 
-**Raw json**
-```json5
+```json
 {
     "version": {
         "protocol": 2000,
-        "name": "1.18.0-pre.6"
+        "name": "1.19.0"
     },
     "players": {
         "max": 16,
         "online": 1,
         "sample": [
             {
-                "name": "Nyuhnyash",
+                "name": "RainYbit",
                 "id": "3e4a67aa-c4f1-f5f7-dffd-37e2fad5f74d"
             }
         ]
@@ -74,9 +102,13 @@ Operate raw json to access non-standard extensions data.
         "text": "Vintage Story Server"
     },
     "favicon": "data:image/png;base64,<...>",
-// Non-standard extension
     "world": {
         "datetime": "2. May, Year 0, 17:31"
     }
 }
 ```
+
+## Credits
+
+- Original mod by [Nyuhnyash](https://github.com/Nyuhnyash/VSStatusServer)
+- Revised version by RainYbit

--- a/StatusServer.csproj
+++ b/StatusServer.csproj
@@ -4,7 +4,8 @@
         <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>6</LangVersion>
         <RootNamespace>StatusServer</RootNamespace>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
+        <NoWarn>$(NoWarn);MSB3277</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/StatusServer.csproj
+++ b/StatusServer.csproj
@@ -5,7 +5,6 @@
         <LangVersion>6</LangVersion>
         <RootNamespace>StatusServer</RootNamespace>
         <Version>1.0.3</Version>
-        <NoWarn>$(NoWarn);MSB3277</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/StatusServer.csproj
+++ b/StatusServer.csproj
@@ -2,9 +2,10 @@
     
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>6</LangVersion>
+        <LangVersion>7.3</LangVersion>
         <RootNamespace>StatusServer</RootNamespace>
-        <Version>1.0.3</Version>
+        <AssemblyName>StatusServerRevised</AssemblyName>
+        <Version>1.0.0</Version>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,6 +18,7 @@
             <Private>false</Private>
         </Reference>
     </ItemGroup>
+    
 
     <ItemGroup>
         <None Include="modinfo.json" CopyToOutputDirectory="PreserveNewest"/>

--- a/modinfo.json
+++ b/modinfo.json
@@ -1,15 +1,15 @@
 {
 	"type": "code",
-	"name": "Status Server",
-	"modid": "statusserver",
-	"version": "1.0.3",
+	"name": "Status Server Revised",
+	"modid": "statusserverrevised",
+	"version": "1.0.0",
 	"side": "server",
 	
 	"description" : "Provides game server information via Server List Ping protocol",
-	"website": "https://github.com/Nyuhnyash/VSStatusServer",
-	"authors": [ "Nyuhnyash" ],
+	"website": "https://github.com/dotpixel/VSStatusServer",
+	"authors": [ "RainYbit" ],
 	
 	"dependencies": {
-		"game": "1.15.0"
+		"game": "1.21.0"
 	}
 }

--- a/modinfo.json
+++ b/modinfo.json
@@ -2,7 +2,7 @@
 	"type": "code",
 	"name": "Status Server",
 	"modid": "statusserver",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"side": "server",
 	
 	"description" : "Provides game server information via Server List Ping protocol",

--- a/src/Extensions/ExtensionRegistry.cs
+++ b/src/Extensions/ExtensionRegistry.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using StatusServer.ServerListPing.Standard.Extension;
+using Vintagestory.API.Common;
+using Vintagestory.API.Server;
+
+
+namespace StatusServer.Extensions
+{
+    /// <summary>
+    /// Registry for status extensions. 
+    /// Manages enabled extensions and applies them to payloads.
+    /// </summary>
+    public class ExtensionRegistry
+    {
+        private readonly List<IStatusExtension> _enabledExtensions = new List<IStatusExtension>();
+        private readonly ILogger _logger;
+        
+        public ExtensionRegistry(ILogger logger)
+        {
+            _logger = logger;
+        }
+        
+        /// <summary>
+        /// Registers and enables extensions based on configuration.
+        /// </summary>
+        /// <param name="enabledNames">Names of extensions to enable</param>
+        public void RegisterExtensions(IEnumerable<string> enabledNames)
+        {
+            var enabledSet = new HashSet<string>(enabledNames, StringComparer.OrdinalIgnoreCase);
+            
+            // Register built-in extensions
+            var builtInExtensions = new IStatusExtension[]
+            {
+                new WorldExtension(),
+                // Add more built-in extensions here
+            };
+            
+            foreach (var extension in builtInExtensions)
+            {
+                if (enabledSet.Contains(extension.Name))
+                {
+                    _enabledExtensions.Add(extension);
+                    _logger.Debug($"Enabled status extension: {extension.Name}");
+                }
+            }
+            
+            _logger.Notification($"Loaded {_enabledExtensions.Count} status extension(s)");
+        }
+        
+        /// <summary>
+        /// Registers a custom extension at runtime.
+        /// </summary>
+        /// <param name="extension">The extension to register</param>
+        public void RegisterCustomExtension(IStatusExtension extension)
+        {
+            if (extension == null) throw new ArgumentNullException(nameof(extension));
+            
+            // Check for duplicate names
+            if (_enabledExtensions.Any(e => e.Name.Equals(extension.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger.Warning($"Extension '{extension.Name}' is already registered, skipping");
+                return;
+            }
+            
+            _enabledExtensions.Add(extension);
+            _logger.Debug($"Registered custom extension: {extension.Name}");
+        }
+        
+        /// <summary>
+        /// Applies all enabled extensions to the payload.
+        /// </summary>
+        /// <param name="payload">The payload to modify</param>
+        /// <param name="api">The server API</param>
+        public void ApplyExtensions(ExtendedStatusPayload payload, ICoreServerAPI api)
+        {
+            foreach (var extension in _enabledExtensions)
+            {
+                try
+                {
+                    extension.Apply(payload, api);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"Error applying extension '{extension.Name}': {ex.Message}");
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Gets the count of enabled extensions.
+        /// </summary>
+        public int EnabledCount => _enabledExtensions.Count;
+    }
+}

--- a/src/Extensions/IStatusExtension.cs
+++ b/src/Extensions/IStatusExtension.cs
@@ -1,0 +1,26 @@
+using StatusServer.ServerListPing.Standard.Extension;
+using Vintagestory.API.Server;
+
+
+namespace StatusServer.Extensions
+{
+    /// <summary>
+    /// Interface for status payload extensions.
+    /// Implement this interface to add custom data to the status response.
+    /// </summary>
+    public interface IStatusExtension
+    {
+        /// <summary>
+        /// The unique name of this extension (used in config to enable/disable).
+        /// </summary>
+        string Name { get; }
+        
+        /// <summary>
+        /// Apply extension data to the payload.
+        /// Called for each status request.
+        /// </summary>
+        /// <param name="payload">The payload to modify</param>
+        /// <param name="api">The server API for accessing game data</param>
+        void Apply(ExtendedStatusPayload payload, ICoreServerAPI api);
+    }
+}

--- a/src/Extensions/WorldExtension.cs
+++ b/src/Extensions/WorldExtension.cs
@@ -1,0 +1,23 @@
+using StatusServer.ServerListPing.Standard.Extension;
+using Vintagestory.API.Server;
+
+
+namespace StatusServer.Extensions
+{
+    /// <summary>
+    /// Extension that adds world/calendar information to the status response.
+    /// </summary>
+    public class WorldExtension : IStatusExtension
+    {
+        public string Name => "world";
+        
+        public void Apply(ExtendedStatusPayload payload, ICoreServerAPI api)
+        {
+            var calendar = api.World?.Calendar;
+            payload.World = new WorldPayload
+            {
+                Datetime = calendar?.PrettyDate() ?? "",
+            };
+        }
+    }
+}

--- a/src/ModConfig.cs
+++ b/src/ModConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 
@@ -6,26 +6,66 @@ namespace StatusServer
 {
     public class ModConfig
     {
-        public ushort Port;
-        public string IconFile;
-        public int StartDelaySeconds;
+        public ushort Port { get; set; }
+        
+        public string IconFile { get; set; }
+        
+        public int StartDelaySeconds { get; set; }
+        
         private IEnumerable<string> _enabledExtensions;
 
         public IEnumerable<string> EnabledExtensions
         {
-            get { return _enabledExtensions ?? Array.Empty<string>(); }
-            set { _enabledExtensions = value; }
+            get => _enabledExtensions ?? Array.Empty<string>();
+            set => _enabledExtensions = value;
         }
+        
+        // Server options
+        
+        /// <summary>
+        /// Client connection timeout in milliseconds.
+        /// </summary>
+        public int ClientTimeoutMs { get; set; }
+        
+        /// <summary>
+        /// Maximum pending connections in the listen backlog.
+        /// </summary>
+        public int Backlog { get; set; }
+        
+        /// <summary>
+        /// Maximum number of concurrent client connections.
+        /// </summary>
+        public int MaxConcurrentConnections { get; set; }
+        
+        /// <summary>
+        /// Enable rate limiting per IP address.
+        /// </summary>
+        public bool EnableRateLimiting { get; set; }
+        
+        /// <summary>
+        /// Rate limit time window in seconds.
+        /// </summary>
+        public int RateLimitWindowSeconds { get; set; }
+        
+        /// <summary>
+        /// Maximum requests allowed per IP within the rate limit window.
+        /// </summary>
+        public int RateLimitMaxRequests { get; set; }
 
-        public static ModConfig Default
+        public static ModConfig Default => new ModConfig
         {
-            get { return new ModConfig
-            {
-                Port = 25565,
-                IconFile = "server-icon.png",
-                StartDelaySeconds = 10,
-                EnabledExtensions = new List<string> { "world" },
-            }; }
-        }
+            Port = 25565,
+            IconFile = "server-icon.png",
+            StartDelaySeconds = 10,
+            EnabledExtensions = new List<string> { "world" },
+            
+            // Server defaults
+            ClientTimeoutMs = 5000,
+            Backlog = 10,
+            MaxConcurrentConnections = 50,
+            EnableRateLimiting = true,
+            RateLimitWindowSeconds = 60,
+            RateLimitMaxRequests = 30,
+        };
     }
 }

--- a/src/ModConfig.cs
+++ b/src/ModConfig.cs
@@ -8,6 +8,7 @@ namespace StatusServer
     {
         public ushort Port;
         public string IconFile;
+        public int StartDelaySeconds;
         private IEnumerable<string> _enabledExtensions;
 
         public IEnumerable<string> EnabledExtensions
@@ -22,6 +23,7 @@ namespace StatusServer
             {
                 Port = 25565,
                 IconFile = "server-icon.png",
+                StartDelaySeconds = 10,
                 EnabledExtensions = new List<string> { "world" },
             }; }
         }

--- a/src/ServerListPing/SLPServer.cs
+++ b/src/ServerListPing/SLPServer.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
+using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
-using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -14,166 +16,446 @@ namespace StatusServer.ServerListPing
 {
     public class StatusTcpServer : IStatusServer
     {
+        // Cached JSON settings for better performance
+        private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+        };
+
+        // Simple thread-local buffer pool to reduce allocations
+        private static readonly ThreadLocal<byte[]> BufferPool = new ThreadLocal<byte[]>(() => new byte[8192]);
+
         private readonly ILogger _logger;
         private readonly TcpListener _listener;
-
-        public System.Func<StatusPayload> GetStatusPayload { get; set; }
+        private readonly CancellationTokenSource _cts;
+        private readonly ServerOptions _options;
         
-        public StatusTcpServer(ILogger logger, ushort port)
+        // Rate limiting: track requests per IP
+        private readonly ConcurrentDictionary<string, RateLimitEntry> _rateLimiter;
+        
+        private Task _listenTask;
+        private volatile bool _isRunning;
+        private int _activeConnections;
+
+        public Func<StatusPayload> GetStatusPayload { get; set; }
+        
+        public StatusTcpServer(ILogger logger, ushort port) 
+            : this(logger, port, ServerOptions.Default)
+        {
+        }
+        
+        public StatusTcpServer(ILogger logger, ushort port, ServerOptions options)
         {
             _logger = logger;
             _listener = new TcpListener(IPAddress.Any, port);
+            _cts = new CancellationTokenSource();
+            _options = options ?? ServerOptions.Default;
+            _rateLimiter = new ConcurrentDictionary<string, RateLimitEntry>();
         }
         
-        public async void Start()
+        public void Start()
         {
-            _listener.Start();
-
-            try
+            _listener.Start(_options.Backlog);
+            _isRunning = true;
+            _listenTask = Task.Run(() => ListenAsync(_cts.Token));
+            
+            // Start rate limiter cleanup task
+            if (_options.EnableRateLimiting)
             {
-                await Listen();
-            }
-            catch (Exception e)
-            {
-                if (e is ObjectDisposedException)
-                    return;
-
-                _logger.Error(e.Message + e.StackTrace);
-                _logger.Notification("Status server stopped due an exception");
+                Task.Run(() => RateLimiterCleanupAsync(_cts.Token));
             }
         }
 
         public void Dispose()
         {
+            _isRunning = false;
+            _cts.Cancel();
             _listener.Stop();
+            
+            // Wait for listen task to complete with timeout
+            try
+            {
+                _listenTask?.Wait(TimeSpan.FromSeconds(2));
+            }
+            catch (AggregateException)
+            {
+                // Task was cancelled, this is expected
+            }
+            
+            _cts.Dispose();
+            _rateLimiter.Clear();
         }
 
-        private async Task Listen()
+        private async Task ListenAsync(CancellationToken cancellationToken)
         {
-            try { 
-                while (true)
+            try
+            {
+                while (_isRunning && !cancellationToken.IsCancellationRequested)
                 {
-                    var client = await _listener.AcceptTcpClientAsync();
-                    var stream = client.GetStream();
-
-                    var reader = new BinaryReader(stream);
-
-                    // Handshake: https://wiki.vg/Protocol#Handshake
-                    /* Packet length */ var length = reader.Read7BitEncodedInt();
-                    if (length == 0xFE) // Legacy
+                    try
                     {
-                        var legacyPayload = LegacyStatusResponse();
-                        stream.Write(legacyPayload, 0, legacyPayload.Length);
-                        client.Close();
-                        continue;
+                        var client = await _listener.AcceptTcpClientAsync();
+                        
+                        // Check max connections
+                        if (_activeConnections >= _options.MaxConcurrentConnections)
+                        {
+                            client.Close();
+                            continue;
+                        }
+                        
+                        // Handle client in a separate task for parallelism
+                        _ = HandleClientAsync(client, cancellationToken);
                     }
-
-                    /* Packet ID (0) */ reader.ReadByte();
-                    /* Protocol (47) */ reader.Read7BitEncodedInt();
-                    /* Host */          reader.ReadString();
-                    /* Port */          reader.ReadUInt16();
-                    var state = reader.Read7BitEncodedInt();
-
-                    if (state != 1) continue; // Login (ignore)
-
-                    HandlePacket(stream);
-
-                    // Follow-on ping (optional)
-                    HandlePacket(stream);
-                    client.Close();
+                    catch (ObjectDisposedException)
+                    {
+                        // Listener was stopped, exit gracefully
+                        return;
+                    }
+                    catch (SocketException ex)
+                    {
+                        if (_isRunning)
+                        {
+                            _logger.Warning("Socket error accepting client: " + ex.Message);
+                        }
+                    }
                 }
             }
-            catch (TargetInvocationException) { }
-            catch (IOException) { }
-            catch (SocketException) { }
+            catch (Exception ex)
+            {
+                if (_isRunning)
+                {
+                    _logger.Error("Fatal error in status server: " + ex);
+                    _logger.Notification("Status server stopped due to an exception");
+                }
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient client, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _activeConnections);
+            
+            try
+            {
+                // Set timeouts to prevent slow/malicious clients
+                client.ReceiveTimeout = _options.ClientTimeoutMs;
+                client.SendTimeout = _options.ClientTimeoutMs;
+                
+                // Rate limiting check
+                if (_options.EnableRateLimiting)
+                {
+                    var clientIp = ((IPEndPoint)client.Client.RemoteEndPoint).Address.ToString();
+                    if (!CheckRateLimit(clientIp))
+                    {
+                        _logger.Debug("Rate limit exceeded for " + clientIp);
+                        return;
+                    }
+                }
+                
+                await Task.Run(() => HandleClient(client), cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // Shutdown requested
+            }
+            catch (IOException ex)
+            {
+                _logger.Debug("IO error handling client: " + ex.Message);
+            }
+            catch (SocketException ex)
+            {
+                if (_isRunning)
+                {
+                    _logger.Debug("Socket error handling client: " + ex.Message);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error("Error handling client: " + ex);
+            }
+            finally
+            {
+                client.Close();
+                Interlocked.Decrement(ref _activeConnections);
+            }
+        }
+
+        private bool CheckRateLimit(string clientIp)
+        {
+            var now = DateTime.UtcNow;
+            var entry = _rateLimiter.GetOrAdd(clientIp, _ => new RateLimitEntry());
+            
+            lock (entry)
+            {
+                // Reset if window expired
+                if ((now - entry.WindowStart).TotalSeconds >= _options.RateLimitWindowSeconds)
+                {
+                    entry.WindowStart = now;
+                    entry.RequestCount = 0;
+                }
+                
+                entry.RequestCount++;
+                return entry.RequestCount <= _options.RateLimitMaxRequests;
+            }
+        }
+
+        private async Task RateLimiterCleanupAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromMinutes(1), cancellationToken);
+                    
+                    var now = DateTime.UtcNow;
+                    var expiredKeys = _rateLimiter
+                        .Where(kvp => (now - kvp.Value.WindowStart).TotalSeconds > _options.RateLimitWindowSeconds * 2)
+                        .Select(kvp => kvp.Key)
+                        .ToList();
+                    
+                    foreach (var key in expiredKeys)
+                    {
+                        _rateLimiter.TryRemove(key, out _);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.Debug("Rate limiter cleanup error: " + ex.Message);
+                }
+            }
+        }
+
+        private void HandleClient(TcpClient client)
+        {
+            using (var stream = client.GetStream())
+            using (var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true))
+            {
+                // Handshake: https://wiki.vg/Protocol#Handshake
+                var length = reader.Read7BitEncodedInt();
+                
+                if (length == 0xFE) // Legacy ping
+                {
+                    SendLegacyResponse(stream);
+                    return;
+                }
+
+                /* Packet ID (0) */ reader.ReadByte();
+                /* Protocol (47) */ reader.Read7BitEncodedInt();
+                /* Host */          reader.ReadString();
+                /* Port */          reader.ReadUInt16();
+                var state = reader.Read7BitEncodedInt();
+
+                if (state != 1) return; // Login state - ignore
+
+                // Handle status request
+                HandlePacket(stream, reader);
+
+                // Handle follow-on ping (optional)
+                if (stream.DataAvailable)
+                {
+                    HandlePacket(stream, reader);
+                }
+            }
         }
         
         /// <summary>
+        /// Handles a single packet from the client.
         /// https://wiki.vg/Protocol#Packet_format
         /// </summary>
-        private void HandlePacket(NetworkStream stream)
+        private void HandlePacket(NetworkStream stream, BinaryReader reader)
         {
-            var reader = new BinaryReader(stream);
             /* Packet length */
             reader.Read7BitEncodedInt();
             var packetID = (byte)reader.Read7BitEncodedInt();
 
-            byte[] payload;
             switch (packetID)
             {
-                case 0: // Status
-                    payload = StatusResponse();
+                case 0: // Status request
+                    SendStatusResponse(stream);
                     break;
 
                 case 1: // Ping
-                    var pong = reader.ReadInt64();
-                    payload = BitConverter.GetBytes(pong);
+                    SendPingResponse(stream, reader.ReadInt64());
                     break;
-
-                default: return; // Ignore unknown packets
             }
-
-            SendPacket(stream, packetID, payload); 
         }
 
         /// <summary>
-        /// https://wiki.vg/Protocol#Packet_format
-        /// </summary>
-        private void SendPacket(NetworkStream stream, byte packetID, byte[] payload)
-        {
-            var buffer = new MemoryStream();
-            var writer = new BinaryWriter(buffer);
-            writer.Write7BitEncodedInt(1 + payload.Length);
-            writer.Write(packetID);
-            writer.Write(payload);
-            
-            var output = buffer.ToArray();
-            stream.Write(output, 0, output.Length);
-        }
-
-        /// <summary>
+        /// Sends status response using thread-local buffer.
         /// https://wiki.vg/Server_List_Ping#Status_Response
         /// </summary>
-        /// <returns>Packet 0x00 response payload</returns>
-        private byte[] StatusResponse()
+        private void SendStatusResponse(NetworkStream stream)
         {
-            var json = JsonConvert.SerializeObject(GetStatusPayload(), Formatting.None, new JsonSerializerSettings()
-            {
-                NullValueHandling = NullValueHandling.Ignore,
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
-            });
+            var json = JsonConvert.SerializeObject(GetStatusPayload(), Formatting.None, JsonSettings);
             var jsonBytes = Encoding.UTF8.GetBytes(json);
             
-            var buffer = new MemoryStream();
-            var writer = new BinaryWriter(buffer);
-            writer.Write7BitEncodedInt(jsonBytes.Length);
-            writer.Write(jsonBytes);
-            writer.Close();
-            return buffer.ToArray();
+            // Calculate packet size: VarInt length prefix + packet ID (1) + VarInt json length + json bytes
+            var packetDataLength = 1 + GetVarIntSize(jsonBytes.Length) + jsonBytes.Length;
+            var totalSize = GetVarIntSize(packetDataLength) + packetDataLength;
+            
+            // Use thread-local buffer if large enough, otherwise allocate
+            var buffer = totalSize <= BufferPool.Value.Length 
+                ? BufferPool.Value 
+                : new byte[totalSize];
+            
+            var offset = 0;
+            
+            // Write packet length
+            offset += WriteVarInt(buffer, offset, packetDataLength);
+            
+            // Write packet ID (0 for status response)
+            buffer[offset++] = 0;
+            
+            // Write JSON length as VarInt
+            offset += WriteVarInt(buffer, offset, jsonBytes.Length);
+            
+            // Write JSON bytes
+            Buffer.BlockCopy(jsonBytes, 0, buffer, offset, jsonBytes.Length);
+            offset += jsonBytes.Length;
+            
+            stream.Write(buffer, 0, offset);
         }
 
         /// <summary>
+        /// Sends ping response using thread-local buffer.
+        /// </summary>
+        private void SendPingResponse(NetworkStream stream, long pingValue)
+        {
+            var buffer = BufferPool.Value;
+            var offset = 0;
+            
+            // Packet length = 9 (1 byte packet ID + 8 bytes long)
+            offset += WriteVarInt(buffer, offset, 9);
+            
+            // Packet ID (1 for ping)
+            buffer[offset++] = 1;
+            
+            // Ping value (little-endian as per Minecraft protocol)
+            var pingBytes = BitConverter.GetBytes(pingValue);
+            Buffer.BlockCopy(pingBytes, 0, buffer, offset, 8);
+            offset += 8;
+            
+            stream.Write(buffer, 0, offset);
+        }
+
+        /// <summary>
+        /// Sends legacy status response.
         /// https://wiki.vg/Server_List_Ping#Server_to_client
         /// </summary>
-        /// <returns>Full TCP response</returns>
-        private byte[] LegacyStatusResponse()
+        private void SendLegacyResponse(NetworkStream stream)
         {
             var payload = GetStatusPayload();
-            var payloadString = String.Join("\0", 
-                "§1", 
-                127,
-                payload.Version.Name,
-                payload.Description.Text,
-                payload.Players.Online, 
-                payload.Players.Max);
-
-            var output = new byte[3 + 2 * payloadString.Length];
-            output[0] = 0xFF;
-            output[1] = (byte)(((ushort)payloadString.Length >> 8) & 0xFF);
-            output[2] = (byte)payloadString.Length;
-            Encoding.BigEndianUnicode.GetBytes(payloadString, 0, payloadString.Length, output, 3);
             
-            return output;
+            // Build payload string using StringBuilder to reduce allocations
+            var sb = new StringBuilder(256);
+            sb.Append("§1\0");
+            sb.Append("127\0");
+            sb.Append(payload.Version.Name);
+            sb.Append('\0');
+            sb.Append(payload.Description.Text);
+            sb.Append('\0');
+            sb.Append(payload.Players.Online);
+            sb.Append('\0');
+            sb.Append(payload.Players.Max);
+            
+            var payloadString = sb.ToString();
+            var outputLength = 3 + 2 * payloadString.Length;
+            
+            // Use thread-local buffer if large enough
+            var buffer = outputLength <= BufferPool.Value.Length 
+                ? BufferPool.Value 
+                : new byte[outputLength];
+            
+            buffer[0] = 0xFF;
+            buffer[1] = (byte)(((ushort)payloadString.Length >> 8) & 0xFF);
+            buffer[2] = (byte)payloadString.Length;
+            Encoding.BigEndianUnicode.GetBytes(payloadString, 0, payloadString.Length, buffer, 3);
+            
+            stream.Write(buffer, 0, outputLength);
         }
+        
+        /// <summary>
+        /// Calculates the size of a VarInt encoding.
+        /// </summary>
+        private static int GetVarIntSize(int value)
+        {
+            var v = (uint)value;
+            var size = 0;
+            do
+            {
+                size++;
+                v >>= 7;
+            } while (v != 0);
+            return size;
+        }
+        
+        /// <summary>
+        /// Writes a VarInt to a buffer and returns bytes written.
+        /// </summary>
+        private static int WriteVarInt(byte[] buffer, int offset, int value)
+        {
+            var v = (uint)value;
+            var written = 0;
+            
+            while (v >= 0x80)
+            {
+                buffer[offset + written++] = (byte)(v | 0x80);
+                v >>= 7;
+            }
+            
+            buffer[offset + written++] = (byte)v;
+            return written;
+        }
+        
+        /// <summary>
+        /// Rate limiting entry for tracking requests per IP.
+        /// </summary>
+        private class RateLimitEntry
+        {
+            public DateTime WindowStart = DateTime.UtcNow;
+            public int RequestCount;
+        }
+    }
+    
+    /// <summary>
+    /// Server configuration options.
+    /// </summary>
+    public class ServerOptions
+    {
+        /// <summary>
+        /// Client connection timeout in milliseconds.
+        /// </summary>
+        public int ClientTimeoutMs { get; set; } = 5000;
+        
+        /// <summary>
+        /// Maximum pending connections in the listen backlog.
+        /// </summary>
+        public int Backlog { get; set; } = 10;
+        
+        /// <summary>
+        /// Maximum number of concurrent client connections.
+        /// </summary>
+        public int MaxConcurrentConnections { get; set; } = 50;
+        
+        /// <summary>
+        /// Enable rate limiting per IP address.
+        /// </summary>
+        public bool EnableRateLimiting { get; set; } = true;
+        
+        /// <summary>
+        /// Rate limit time window in seconds.
+        /// </summary>
+        public int RateLimitWindowSeconds { get; set; } = 60;
+        
+        /// <summary>
+        /// Maximum requests allowed per IP within the rate limit window.
+        /// </summary>
+        public int RateLimitMaxRequests { get; set; } = 30;
+        
+        public static ServerOptions Default => new ServerOptions();
     }
 }

--- a/src/ServerListPing/Standard/DescriptionPayload.cs
+++ b/src/ServerListPing/Standard/DescriptionPayload.cs
@@ -1,8 +1,8 @@
-﻿namespace StatusServer.ServerListPing.Standard
+namespace StatusServer.ServerListPing.Standard
 {
     public class DescriptionPayload
     {
-        public string Text;
+        public string Text { get; set; }
 
         public static implicit operator DescriptionPayload(string text)
         {

--- a/src/ServerListPing/Standard/Extension/ExtendedStatusPayload.cs
+++ b/src/ServerListPing/Standard/Extension/ExtendedStatusPayload.cs
@@ -1,7 +1,7 @@
-﻿namespace StatusServer.ServerListPing.Standard.Extension
+namespace StatusServer.ServerListPing.Standard.Extension
 {
     public class ExtendedStatusPayload : StatusPayload
     {
-        public WorldPayload World;
+        public WorldPayload World { get; set; }
     }
 }

--- a/src/ServerListPing/Standard/Extension/WorldPayload.cs
+++ b/src/ServerListPing/Standard/Extension/WorldPayload.cs
@@ -1,7 +1,7 @@
-﻿namespace StatusServer.ServerListPing.Standard.Extension
+namespace StatusServer.ServerListPing.Standard.Extension
 {
     public class WorldPayload
     {
-        public string Datetime;
+        public string Datetime { get; set; }
     }
 }

--- a/src/ServerListPing/Standard/PlayerPayload.cs
+++ b/src/ServerListPing/Standard/PlayerPayload.cs
@@ -1,22 +1,24 @@
-﻿using System;
+using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 
 
 namespace StatusServer.ServerListPing.Standard
 {
     public class PlayerPayload
     {
-        private static readonly MD5 _md5 = MD5.Create();
+        // ThreadLocal ensures thread-safety for MD5 computation
+        private static readonly ThreadLocal<MD5> _md5 = new ThreadLocal<MD5>(() => MD5.Create());
 
-        public Guid Id;
+        public Guid Id { get; set; }
 
-        public string Name;
+        public string Name { get; set; }
 
         public PlayerPayload(string name, string hashSource)
         {
             Name = name;
-            Id = new Guid(_md5.ComputeHash(Encoding.UTF8.GetBytes(hashSource)));
+            Id = new Guid(_md5.Value.ComputeHash(Encoding.UTF8.GetBytes(hashSource)));
         }
     }
 }

--- a/src/ServerListPing/Standard/PlayersPayload.cs
+++ b/src/ServerListPing/Standard/PlayersPayload.cs
@@ -1,14 +1,14 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 
 namespace StatusServer.ServerListPing.Standard
 {
     public class PlayersPayload
     {
-        public int Max;
+        public int Max { get; set; }
 
-        public int Online;
+        public int Online { get; set; }
 
-        public IEnumerable<PlayerPayload> Sample;
+        public IEnumerable<PlayerPayload> Sample { get; set; }
     }
 }

--- a/src/ServerListPing/Standard/StatusPayload.cs
+++ b/src/ServerListPing/Standard/StatusPayload.cs
@@ -1,16 +1,16 @@
-﻿namespace StatusServer.ServerListPing.Standard
+namespace StatusServer.ServerListPing.Standard
 {
     public class StatusPayload
     {
-        public VersionPayload Version;
+        public VersionPayload Version { get; set; }
 
-        public PlayersPayload Players;
+        public PlayersPayload Players { get; set; }
         
-        public DescriptionPayload Description;
+        public DescriptionPayload Description { get; set; }
 
         /// <summary>
         /// Server icon, encoded in Base64
         /// </summary>
-        public string Favicon;
+        public string Favicon { get; set; }
     }
 }

--- a/src/ServerListPing/Standard/VersionPayload.cs
+++ b/src/ServerListPing/Standard/VersionPayload.cs
@@ -1,10 +1,10 @@
-﻿namespace StatusServer.ServerListPing.Standard
+namespace StatusServer.ServerListPing.Standard
 {
     public class VersionPayload
     {
-        public readonly int Protocol = 2000;
+        public int Protocol { get; } = 2000;
 
-        public string Name;
+        public string Name { get; set; }
 
         public static implicit operator VersionPayload(string name)
         {


### PR DESCRIPTION
Fixed errors like this:

27.1.2026 20:07:31 [Error] [statusserver] Object reference not set to an instance of an object.   at StatusServer.StatusServerMod.<>c__DisplayClass1_0.<StartServerSide>b__0()
   at StatusServer.ServerListPing.StatusTcpServer.StatusResponse()
   at StatusServer.ServerListPing.StatusTcpServer.HandlePacket(NetworkStream stream)
   at StatusServer.ServerListPing.StatusTcpServer.Listen()
   at StatusServer.ServerListPing.StatusTcpServer.Start()
27.1.2026 20:07:31 [Notification] [statusserver] Status server stopped due an exception
